### PR TITLE
Improve error handling for AI streaming responses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@ai-sdk/anthropic": "1.2.12",
+        "@anthropic-ai/sdk": "^0.79.0",
         "@babel/standalone": "^7.27.6",
         "@monaco-editor/react": "^4.7.0",
         "@prisma/client": "^6.10.1",
@@ -169,6 +170,26 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.79.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.79.0.tgz",
+      "integrity": "sha512-ietmtM6glcnnrWq26H+BZm8J07iay9Cob6hRzDTr/A9QWF1m2T//TQhFO4MTKcZht2/7LS8bG9wUYEhcizKRnA==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -453,7 +474,6 @@
       "version": "7.27.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
       "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -7590,6 +7610,19 @@
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -10564,6 +10597,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "1.2.12",
+    "@anthropic-ai/sdk": "^0.79.0",
     "@babel/standalone": "^7.27.6",
     "@monaco-editor/react": "^4.7.0",
     "@prisma/client": "^6.10.1",

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,6 +1,7 @@
 import type { FileNode } from "@/lib/file-system";
 import { VirtualFileSystem } from "@/lib/file-system";
 import { streamText, appendResponseMessages } from "ai";
+import { APIError } from "@anthropic-ai/sdk";
 import { buildStrReplaceTool } from "@/lib/tools/str-replace";
 import { buildFileManagerTool } from "@/lib/tools/file-manager";
 import { prisma } from "@/lib/prisma";
@@ -81,18 +82,10 @@ export async function POST(req: Request) {
 
   return result.toDataStreamResponse({
     getErrorMessage: (error) => {
-      if (error instanceof Error) {
-        // Forward specific Anthropic API error messages
-        const msg = error.message;
-        if (msg.includes("401") || msg.toLowerCase().includes("authentication") || msg.toLowerCase().includes("api key")) {
-          return "Invalid or missing API key. Please check your ANTHROPIC_API_KEY.";
-        }
-        if (msg.includes("429") || msg.toLowerCase().includes("rate limit")) {
-          return "Rate limit exceeded. Please wait a moment and try again.";
-        }
-        if (msg.includes("529") || msg.toLowerCase().includes("overloaded")) {
-          return "The AI service is temporarily overloaded. Please try again shortly.";
-        }
+      if (error instanceof APIError) {
+        if (error.status === 401) return "Invalid or missing API key. Please check your ANTHROPIC_API_KEY.";
+        if (error.status === 429) return "Rate limit exceeded. Please wait a moment and try again.";
+        if (error.status === 529) return "The AI service is temporarily overloaded. Please try again shortly.";
       }
       return "An unexpected error occurred. Please try again.";
     },

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -36,8 +36,8 @@ export async function POST(req: Request) {
     messages,
     maxTokens: 10_000,
     maxSteps: isMockProvider ? 4 : 40,
-    onError: (err: any) => {
-      console.error(err);
+    onError: ({ error }) => {
+      console.error("streamText error:", error);
     },
     tools: {
       str_replace_editor: buildStrReplaceTool(fileSystem),
@@ -79,7 +79,24 @@ export async function POST(req: Request) {
     },
   });
 
-  return result.toDataStreamResponse();
+  return result.toDataStreamResponse({
+    getErrorMessage: (error) => {
+      if (error instanceof Error) {
+        // Forward specific Anthropic API error messages
+        const msg = error.message;
+        if (msg.includes("401") || msg.toLowerCase().includes("authentication") || msg.toLowerCase().includes("api key")) {
+          return "Invalid or missing API key. Please check your ANTHROPIC_API_KEY.";
+        }
+        if (msg.includes("429") || msg.toLowerCase().includes("rate limit")) {
+          return "Rate limit exceeded. Please wait a moment and try again.";
+        }
+        if (msg.includes("529") || msg.toLowerCase().includes("overloaded")) {
+          return "The AI service is temporarily overloaded. Please try again shortly.";
+        }
+      }
+      return "An unexpected error occurred. Please try again.";
+    },
+  });
 }
 
 export const maxDuration = 120;

--- a/src/components/chat/ChatInterface.tsx
+++ b/src/components/chat/ChatInterface.tsx
@@ -5,10 +5,11 @@ import { MessageList } from "./MessageList";
 import { MessageInput } from "./MessageInput";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useChat } from "@/lib/contexts/chat-context";
+import { AlertCircle } from "lucide-react";
 
 export function ChatInterface() {
   const scrollAreaRef = useRef<HTMLDivElement>(null);
-  const { messages, input, handleInputChange, handleSubmit, status } = useChat();
+  const { messages, input, handleInputChange, handleSubmit, status, error } = useChat();
 
   // Auto-scroll to bottom when new messages arrive
   useEffect(() => {
@@ -29,6 +30,12 @@ export function ChatInterface() {
           <MessageList messages={messages} isLoading={status === "streaming"} />
         </div>
       </ScrollArea>
+      {error && (
+        <div className="mt-3 flex-shrink-0 flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 px-3 py-2.5 text-sm text-red-700">
+          <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+          <span>{error.message}</span>
+        </div>
+      )}
       <div className="mt-4 flex-shrink-0">
         <MessageInput
           input={input}

--- a/src/lib/contexts/chat-context.tsx
+++ b/src/lib/contexts/chat-context.tsx
@@ -22,6 +22,7 @@ interface ChatContextType {
   handleInputChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
   handleSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
   status: string;
+  error: Error | undefined;
 }
 
 const ChatContext = createContext<ChatContextType | undefined>(undefined);
@@ -39,6 +40,7 @@ export function ChatProvider({
     handleInputChange,
     handleSubmit,
     status,
+    error,
   } = useAIChat({
     api: "/api/chat",
     initialMessages,
@@ -66,6 +68,7 @@ export function ChatProvider({
         handleInputChange,
         handleSubmit,
         status,
+        error,
       }}
     >
       {children}


### PR DESCRIPTION
## Summary
- Surface user-friendly error messages from the API route via `getErrorMessage`, handling 401/auth, 429/rate-limit, and 529/overload cases
- Expose `error` state from `useAIChat` through `ChatContext`
- Display an inline error banner in `ChatInterface` with an `AlertCircle` icon when an error occurs

## Test plan
- [ ] Trigger a 401 error (invalid API key) and verify the error banner shows the auth message
- [ ] Verify rate-limit and overload error messages display correctly
- [ ] Confirm the error banner disappears on a successful subsequent request
- [ ] Check no regression in normal chat flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)